### PR TITLE
Fix page freeze upon returning

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,7 +1,18 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
 	reactStrictMode: true,
-	output: "standalone"
+	output: "standalone",
+	headers: () => [
+		{
+			source: "/:path*",
+			headers: [
+				{
+					key: "Cache-Control",
+					value: "no-store"
+				}
+			]
+		}
+	]
 }
 
 module.exports = nextConfig


### PR DESCRIPTION
<!-- Filling out the template is required. You can keep it simple, but please describe as much as you can -->
### Description of the Change
Fixed #17 
A temporary fix for Firefox browser state caching breaking app after returning back to app using browser back function.

### Possible Drawbacks
Currently disabled caching, which is not an elegant solution but performance-wise not much to cache anyway, so until other features require better state management, I will not improve this.
