### PR TITLE
Add the everforest dark theme

### DIFF
--- a/public/themes/everforest-dark.json
+++ b/public/themes/everforest-dark.json
@@ -1,0 +1,16 @@
+{
+	"backgroundColor": "#232a2e",
+	"windowColor": "#2d353b",
+	"glowColor": "#425047",
+	"white": "#d3c6aa",
+	"gray": "#7a8478",
+	"black": "#000000",
+	"red": "#e67e80",
+	"green": "#a7c080",
+	"yellow": "#dbbc7f",
+	"blue": "#7fbbb3",
+	"cyan": "#83c092",
+	"magenta": "#d699b6",
+	"violet": "#d699b6",
+	"orange": "#e69875"
+}

--- a/src/utils/themes.js
+++ b/src/utils/themes.js
@@ -3,6 +3,7 @@ export const themes = [
 	"bushido",
 	"catppuccin",
 	"dracula",
+	"everforest-dark",
 	"hacker",
 	"monokai",
 	"nord",


### PR DESCRIPTION
<!-- 
	Filling out the template is required. You can keep it simple, but please describe as much as you can

	Please read contributing guideline for more information:
	https://github.com/excalith/excalith-start-page/blob/main/.github/CONTRIBUTING.md
-->

### Description of the Change

Big fan of the project and I am currently using it as my homepage. Locally I use the Everforest medium dark theme, so I thought that I would contribute it to the project. Feel free to merge or reject. Let me know if there are any changes needed.

Everforest theme credit: https://github.com/sainnhe/everforest

![image](https://github.com/excalith/excalith-start-page/assets/9153064/8dcd9e0f-b16e-443f-89b0-f21822b0a1da)

### Possible Drawbacks

No possible drawbacks
