### PR TITLE
Update RunCommand open url to only prepend 'https://' if it's missing

### DIFF
--- a/src/utils/command.js
+++ b/src/utils/command.js
@@ -11,7 +11,10 @@ export function RunCommand(command, settings) {
 	if (registeredCommands.includes(cmd_split[0])) {
 		publish("command", cmd_split)
 	} else if (isURL(command)) {
-		openLink("https://" + command, settings.urlLaunch.target)
+		openLink(
+			(/^https?:\/\//.test(command) ? "" : "https://") + command,
+			settings.urlLaunch.target
+		)
 	} else if (tryParseSearchShortcut(command, settings)) {
 		return
 	} else {


### PR DESCRIPTION
<!-- 
	Filling out the template is required. You can keep it simple, but please describe as much as you can

	Please read contributing guideline for more information:
	https://github.com/excalith/excalith-start-page/blob/main/.github/CONTRIBUTING.md
-->

### Description of the Change
<!-- What have you changed and why -->
<!-- If applicable, screenshot of the changes -->
I have modified the `openLink` section of the `RunCommand` function to only prepend `'https://'` to the URL if it doesn't already include it.

I was finding that I was unable to paste in a URL and go to it, because it would take me to `https://https://github.com`, which doesn't work. This uses regex to detect if the URL matches `^https?:\/\/`, and if so, don't prepend `'https://'`.

This should resolve #45.

### Possible Drawbacks
<!-- Possible side-effects or negative impacts of the code change -->
- Some people don't like ternary statements, but this one is small enough that it shouldn't be problematic.