### PR TITLE
Search without Autocompletion

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,8 @@ Please refer to [configuration](https://github.com/excalith/excalith-start-page/
 ### Key Bindings
 
 - Use <kbd>→</kbd> to auto-complete the suggestion
-- Cycle through filtered links using <kbd>TAB</kbd> and <kbd>SHIFT</kbd> + <kbd> TAB</kbd>
+- Search without auto-complete with <kbd>CTRL</kbd> + <kbd>ENTER</kbd>
+- Cycle through filtered links using <kbd>TAB</kbd> and <kbd>SHIFT</kbd> + <kbd>TAB</kbd>
 - Clear the prompt quickly with <kbd>CTRL</kbd> + <kbd>C</kbd>
 - Close windows with <kbd>ESC</kbd>
 

--- a/src/components/Search.js
+++ b/src/components/Search.js
@@ -1,5 +1,5 @@
 import React, { useRef, useEffect, useState } from "react"
-import { RunCommand } from "@/utils/command"
+import { RunCommand, DefaultSearch } from "@/utils/command"
 import Prompt from "@/components/Prompt"
 import { useSettings } from "@/context/settings"
 
@@ -23,12 +23,14 @@ const Search = ({ commandChange, selectionChange }) => {
 	// Key Down
 	useEffect(() => {
 		const handleKeyDown = (e) => {
+			const isCtrlPressed = e.metaKey || e.ctrlKey
 			// Submit prompt
 			if (e.key === "Enter") {
-				RunCommand(command, settings)
+				const search_function = isCtrlPressed ? DefaultSearch : RunCommand
+				search_function(command, settings)
 			}
 			// Clear prompt
-			else if ((e.metaKey || e.ctrlKey) && e.code === "KeyC") {
+			else if (isCtrlPressed && e.code === "KeyC") {
 				if (settings.prompt.ctrlC) {
 					inputRef.current.value = ""
 					selectionChange("")

--- a/src/utils/command.js
+++ b/src/utils/command.js
@@ -38,14 +38,18 @@ function openFilteredLinks(command, settings) {
 
 	let filterCount = filteredUrls.length
 	if (filterCount === 0) {
-		const defaultSerachEngine = settings.search.default
-		const target = settings.search.target
-		openLink(defaultSerachEngine + command, target)
+		DefaultSearch(command, settings)
 	} else {
 		filteredUrls.map((url, index) => {
 			openLink(url, index === filterCount - 1 ? "_self" : "_blank")
 		})
 	}
+}
+
+export function DefaultSearch(buffer, settings) {
+	const defaultSerachEngine = settings.search.default
+	const target = settings.search.target
+	openLink(defaultSerachEngine + buffer, target)
 }
 
 function tryParseSearchShortcut(command, settings) {


### PR DESCRIPTION
<!-- 
	Filling out the template is required. You can keep it simple, but please describe as much as you can

	Please read contributing guideline for more information:
	https://github.com/excalith/excalith-start-page/blob/main/.github/CONTRIBUTING.md
-->

### Description of the Change
##### src/utils/command.js:
Refactored the 'normal' search into a function called `DefaultSearch` and exposed it.

##### src/components/Search.js:
- imported DefaultSearch to the file.
- Const `isCtrlPressed` to tell if CTRL or META is pressed (refactored from code found).
- Ternary expression to choose  search function and executes that function with parameters.
##### README.md
- Added to keybinds the changes implemented.
- fixed a typo I saw while editing.

### Possible Drawbacks
- Use of the ternary operator could be unreadable however I can read it perfectly and prevents duplicating 2 functions with the same parameters.
- The keybind also ignores commands along with autocompletion however I think people will intend of ignoring it if used. e.g. searching "w hotels" 

### Further note:
I am loving the project and am using it as my home page for my workflow. amazing stuff here and keep up the good work!
