### PR TITLE
[HOTFIX] Docker builds also write localstorage when resetting to defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,8 @@ This is an interactive start page for browsers, inspired from my terminal setup.
 
 You can explore the working version [here](https://excalith-start-page.vercel.app). To get inspired by community members' configurations, visit the [Showcase](https://github.com/excalith/excalith-start-page/discussions/categories/showcase) in discussions!
 
-> **Warning:** This is a demo version and will be updated regularly, which might break your configurations. It is not recommended for daily browsing. Please refer to the [wiki page](https://github.com/excalith/excalith-start-page/wiki/Getting-Started) for more information.
+> [!IMPORTANT]
+> This is a demo version and will be updated regularly, which might break your configurations. It is not recommended for daily browsing. Please refer to the [wiki page](https://github.com/excalith/excalith-start-page/wiki/Getting-Started) for more information.
 
 
 
@@ -28,6 +29,7 @@ You can explore the working version [here](https://excalith-start-page.vercel.ap
 - Launch websites directly from the prompt. Just type the URL (ie. `github.com`)
 - Search websites with custom commands. For example, type `s some weird bug` to search StackOverflow for `some weird bug`
 - Wallpaper support through URL with blur and fade effects
+- Terminal window opacity and translucency effects
 - Customizable Fetch UI for fetching browser and system data, including custom image support
 - Autosuggest and Autocomplete support just like `zsh` and `fish`
 - Cycle through filtered links back and forth

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "start-page",
-    "version": "3.1.0",
+    "version": "3.1.1",
     "private": true,
     "scripts": {
         "dev": "next dev",

--- a/src/context/settings.js
+++ b/src/context/settings.js
@@ -89,7 +89,6 @@ export const SettingsProvider = ({ children }) => {
 	// Reset settings
 	const resetSettings = () => {
 		setSettings(defaultConfig)
-		localStorage.setItem(SETTINGS_KEY, JSON.stringify(defaultConfig))
 	}
 
 	return (


### PR DESCRIPTION
<!-- 
	Filling out the template is required. You can keep it simple, but please describe as much as you can

	Please read contributing guideline for more information:
	https://github.com/excalith/excalith-start-page/blob/main/.github/CONTRIBUTING.md
-->

### Description of the Change
Docker builds uses volumes with v3.1.0 but resetting the configuration still writes into local storage as well. It is not used for reading the configurations, however it is still an unnecessary operation. With this fix, it won't create localstorage entries anymore.

### Possible Drawbacks
Nothing at all.
