### PR TITLE
Asset download ps

### DIFF
--- a/tools/download_assets.ps1
+++ b/tools/download_assets.ps1
@@ -57,7 +57,7 @@ function main {
         $downloadAssets = $false
     }
     else {
-        Write-Host "Invalid value for --assets: $assets. Expected 'true' or 'false'."
+        Write-Host "Invalid value for -assets: $assets. Expected true or false."
         return
     }
 

--- a/tools/download_assets.ps1
+++ b/tools/download_assets.ps1
@@ -1,17 +1,3 @@
-# Example usage:
-# 
-# Set your directory to the root of your mounted dir
-#
-# If you want to download the default assets (icon and wallpaper) set -assets to true
-#
-# If you want to download themes, set -themes followed by theme names. For example:
-# -themes bushido,catppuccin-mocha,onedark
-#
-# https://raw.githubusercontent.com/excalith/excalith-start-page/main/tools/download_assets.ps1
-# Invoke-Expression "$((Invoke-WebRequest -Uri 'https://raw.githubusercontent.com/excalith/excalith-start-page/main/tools/download_assets.ps1').Content) -assets `"true`" -themes bushido,catppuccin-mocha,onedark"
-# Invoke-Expression "$((Invoke-WebRequest -Uri 'https://raw.githubusercontent.com/excalith/excalith-start-page/asset-download-ps/tools/download_assets.ps1').Content) -assets `"true`" -themes bushido,catppuccin-mocha,onedark"
-#Invoke-Expression "$((Invoke-WebRequest -Uri 'https://raw.githubusercontent.com/excalith/excalith-start-page/asset-download-ps/tools/download_assets.ps1').Content) -assets `"true`" -themes bushido,samurai"
-
 #=========================================
 # Variables
 #=========================================

--- a/tools/download_assets.ps1
+++ b/tools/download_assets.ps1
@@ -9,6 +9,8 @@
 #
 # https://raw.githubusercontent.com/excalith/excalith-start-page/main/tools/download_assets.ps1
 # Invoke-Expression "$((Invoke-WebRequest -Uri 'https://raw.githubusercontent.com/excalith/excalith-start-page/main/tools/download_assets.ps1').Content) -assets `"true`" -themes bushido,catppuccin-mocha,onedark"
+# Invoke-Expression "$((Invoke-WebRequest -Uri 'https://raw.githubusercontent.com/excalith/excalith-start-page/asset-download-ps/tools/download_assets.ps1').Content) -assets `"true`" -themes bushido,catppuccin-mocha,onedark"
+#Invoke-Expression "$((Invoke-WebRequest -Uri 'https://raw.githubusercontent.com/excalith/excalith-start-page/asset-download-ps/tools/download_assets.ps1').Content) -assets `"true`" -themes bushido,samurai"
 
 #=========================================
 # Variables
@@ -56,7 +58,7 @@ function main {
     }
     else {
         Write-Host "Invalid value for --assets: $assets. Expected 'true' or 'false'."
-        exit
+        return
     }
 
     # Check if we have themes to download

--- a/tools/download_assets.ps1
+++ b/tools/download_assets.ps1
@@ -1,0 +1,94 @@
+# Example usage:
+# 
+# Set your directory to the root of your mounted dir
+#
+# If you want to download the default assets (icon and wallpaper) set -assets to true
+#
+# If you want to download themes, set -themes followed by theme names. For example:
+# -themes bushido,catppuccin-mocha,onedark
+#
+# https://raw.githubusercontent.com/excalith/excalith-start-page/main/tools/download_assets.ps1
+# Invoke-Expression "$((Invoke-WebRequest -Uri 'https://raw.githubusercontent.com/excalith/excalith-start-page/main/tools/download_assets.ps1').Content) -assets `"true`" -themes bushido,catppuccin-mocha,onedark"
+
+#=========================================
+# Variables
+#=========================================
+param (
+    [Parameter(Mandatory = $false)]
+    [string[]]$themes,
+
+    [Parameter(Mandatory = $false)]
+    [string]$assets
+)
+
+$base_url = "https://raw.githubusercontent.com/excalith/excalith-start-page/main/data/"
+$downloadAssets = $false
+
+#=========================================
+# Download function
+#=========================================
+function download {
+    param (
+        [string]$url,
+        [string]$target,
+        [string]$description
+    )
+
+    try {
+        Invoke-WebRequest -Uri $url -OutFile $target
+        Write-Host "[SUCCESS] Downloaded $description"
+    }
+    catch {
+        Write-Host "[ERROR] Failed to download $description"
+    }
+}
+
+#=========================================
+# Main function
+#=========================================
+function main {
+    # Set assets variable
+    if ($assets -eq "true") {
+        $downloadAssets = $true
+    }
+    elseif ($assets -eq "false") {
+        $downloadAssets = $false
+    }
+    else {
+        Write-Host "Invalid value for --assets: $assets. Expected 'true' or 'false'."
+        exit
+    }
+
+    # Check if we have themes to download
+    if ($themes.Count -gt 0) {
+        Write-Host "Downloading $($themes.Count) themes"
+
+        # Create themes directory if not exists
+        if (!(Test-Path -Path "themes")) {
+            New-Item -ItemType Directory -Force -Path "themes" > $null
+        }
+
+        # Download each theme
+        foreach ($theme in $themes) {
+            download -url "${base_url}/themes/${theme}.json" -target "themes/${theme}.json" -description "${theme} theme"
+        }
+    }
+
+    Write-Host ""
+
+    # Check if we need to download default assets
+    if ($downloadAssets) {
+        Write-Host "Downloading default assets"
+
+        # Create assets directory if not exists
+        if (!(Test-Path -Path "assets")) {
+            New-Item -ItemType Directory -Force -Path "assets" > $null
+        }
+
+        # Download default assets
+        download -url "${base_url}/assets/default-icon.svg" -target "assets/default-icon.svg" -description "default icon"
+        download -url "${base_url}/assets/default-wallpaper.svg" -target "assets/default-wallpaper.svg" -description "default wallpaper"
+    }
+}
+
+main -assets $assets -themes $themes


### PR DESCRIPTION
<!-- 
	Filling out the template is required. You can keep it simple, but please describe as much as you can

	Please read contributing guideline for more information:
	https://github.com/excalith/excalith-start-page/blob/main/.github/CONTRIBUTING.md
-->

### Description of the Change
Added powershell script to allow Windows users download default assets and themes by running this code

```ps
# Modify the params as you wish
$params = @{
    # Set assets to false if you do not want to download the assets
    assets = $true

    # Add themes to the list if you want to download them
    themes = "bushido", "catppuccin-mocha", "onedark"
}

#================================
# Do not modify below this line
#================================

# Set script content
$scriptContent = (Invoke-WebRequest -Uri 'https://raw.githubusercontent.com/excalith/excalith-start-page/asset-download-ps/tools/download_assets.ps1').Content

# Construct a custom script block to handle parameters
$scriptBlock = [scriptblock]::Create("$scriptContent")

# Invoke the modified script with your parameters
& $scriptBlock @params

```

### Possible Drawbacks
Effects nothing on the project
