### PR TITLE
Fix URL Encoding for search buffer

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "start-page",
-    "version": "3.1.1",
+    "version": "3.1.2",
     "private": true,
     "scripts": {
         "dev": "next dev",

--- a/src/utils/command.js
+++ b/src/utils/command.js
@@ -49,7 +49,9 @@ function openFilteredLinks(command, settings) {
 export function DefaultSearch(buffer, settings) {
 	const defaultSerachEngine = settings.search.default
 	const target = settings.search.target
-	openLink(defaultSerachEngine + buffer, target)
+
+	const encodedBuffer = encodeURIComponent(buffer)
+	openLink(defaultSerachEngine + encodedBuffer, target)
 }
 
 function tryParseSearchShortcut(command, settings) {
@@ -67,7 +69,9 @@ function tryParseSearchShortcut(command, settings) {
 
 		if (name === regex_cmd[1]) {
 			const url = commandData.url
-			openLink(url.replace("{}", regex_cmd[2]), settings.urlLaunch.target)
+
+			const encodedBuffer = encodeURIComponent(regex_cmd[2])
+			openLink(url.replace("{}", encodedBuffer, settings.urlLaunch.target))
 			return true
 		}
 	}


### PR DESCRIPTION
<!-- 
	Filling out the template is required. You can keep it simple, but please describe as much as you can

	Please read contributing guideline for more information:
	https://github.com/excalith/excalith-start-page/blob/main/.github/CONTRIBUTING.md
-->

### Description of the Change
Related to #68 

Searching with symbols does not work as intended. Encoding the arguments to search with engines solved this issue.


### Possible Drawbacks
Nothing
