### PR TITLE
Fix blurry text rendering on some platforms

### DIFF
--- a/src/components/Terminal.js
+++ b/src/components/Terminal.js
@@ -57,7 +57,7 @@ const Terminal = () => {
 
 	return (
 		<div
-			className={`absolute w-full h-auto transform -translate-x-1/2 -translate-y-1/2 shadow-lg rounded-terminal bg-window-color max-w-terminal p-terminal top-1/2 left-1/2 ${
+			className={`absolute w-full h-fit inset-x-0 inset-y-0 m-auto shadow-lg rounded-terminal bg-window-color max-w-terminal p-terminal ${
 				settings.terminal.windowGlow && "window-glow"
 			}`}
 			style={windowHeight}

--- a/src/pages/_app.js
+++ b/src/pages/_app.js
@@ -19,7 +19,7 @@ function fallbackRender({ error, resetErrorBoundary }) {
 	}
 
 	return (
-		<div className="absolute w-full h-auto py-4 transform -translate-x-1/2 -translate-y-1/2 shadow-lg text-textColor rounded-terminal bg-window-color max-w-terminal p-terminal top-1/2 left-1/2">
+		<div className="absolute w-full h-fit inset-x-0 inset-y-0 m-auto py-4 shadow-lg text-textColor rounded-terminal bg-window-color max-w-terminal p-terminal">
 			<div role="alert">
 				<p>Something went wrong on your side:</p>
 				<p className="text-red mb-line">{error.message}</p>


### PR DESCRIPTION
<!-- 
	Filling out the template is required. You can keep it simple, but please describe as much as you can

	Please read contributing guideline for more information:
	https://github.com/excalith/excalith-start-page/blob/main/.github/CONTRIBUTING.md
-->

### Description of the Change
This PR changes the way the Terminal is centered in the viewport. The current way of applying a `transform` and `top: 50%`/`left: 50%` causes blurry rendering on some platforms (observed on Chrome 130.0.6723.92 on Windows 11) in cases where a `backdrop-filter` (blur effect) is active. Instead, centering is now done by applying `margin: auto` along with `left`, `top`, `right`, `bottom` set to zero. `height: fit-content` is necessary in order for `fixedHeight` to work correctly.

![before](https://github.com/user-attachments/assets/5c784b36-e6a0-449d-9368-972bce09c2e7)

![after](https://github.com/user-attachments/assets/2c8d79c3-4554-48bd-9d18-e608952e401d)

![ezgif com-animated-gif-maker](https://github.com/user-attachments/assets/731a9746-363a-4489-bedc-809ae2ee81b2)

### Possible Drawbacks
These are layout changes, causing minimal pixel differences. To my eye, rendering looks more correct after these changes.
