### PR TITLE
add gruvbox material theme variants

### DIFF
--- a/data/themes/gruvbox-material-dark.json
+++ b/data/themes/gruvbox-material-dark.json
@@ -1,0 +1,15 @@
+	{
+	"name": "Gruvbox Material Dark",
+	"backgroundColor": "#282828",
+	"windowColor": "#3c3836",
+	"textColor": "#ebdbb2",
+	"black": "#1d2021",
+	"red": "#fb4934",
+	"green": "#b8bb26",
+	"yellow": "#fabd2f",
+	"blue": "#83a598",
+	"magenta": "#d3869b",
+	"cyan": "#8ec07c",
+	"white": "#ebdbb2",
+	"gray": "#928374"
+}

--- a/data/themes/gruvbox-material-light.json
+++ b/data/themes/gruvbox-material-light.json
@@ -1,0 +1,15 @@
+{
+    "name": "Gruvbox Material Light",
+    "backgroundColor": "#fbf1c7",
+    "windowColor": "#f9f5d7",
+    "textColor": "#3c3836",
+    "black": "#282828",
+    "red": "#cc241d",
+    "green": "#98971a",
+    "yellow": "#d79921",
+    "blue": "#458588",
+    "magenta": "#b16286",
+    "cyan": "#689d6a",
+    "white": "#3c3836",
+    "gray": "#928374"
+}


### PR DESCRIPTION
<!-- 
	Filling out the template is required. You can keep it simple, but please describe as much as you can

	Please read contributing guideline for more information:
	https://github.com/excalith/excalith-start-page/blob/main/.github/CONTRIBUTING.md
-->

### Description of the Change
Hey man, I came across this project today and loved the concept of a terminal like look as the browser's new tab page. I primarily use gruvbox material theme and found it missing in this project so I thought to contribute. Please feel free to merge or reject.

Link to theme and credits : https://github.com/sainnhe/gruvbox-material

Below are the screenshots 

**Dark:** 
<img width="2012" alt="image" src="https://github.com/user-attachments/assets/834826d0-7e13-41ef-80a3-3f3f9ab0aaff">

**Light:** 
<img width="2012" alt="image" src="https://github.com/user-attachments/assets/eed366e6-f34c-4d74-b0eb-3e8fabb6e8e1">

If any changes have to made, please let me know

<!-- If applicable, screenshot of the changes -->

### Possible Drawbacks
<!-- Possible side-effects or negative impacts of the code change -->
None