### PR TITLE
Add missing public directory to docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -51,6 +51,7 @@ RUN adduser --system --uid 1001 nextjs
 COPY --from=builder --chown=nextjs:nodejs /app/.next/standalone ./
 COPY --from=builder --chown=nextjs:nodejs /app/.next/static ./.next/static
 COPY --from=builder --chown=nextjs:nodejs /app/data ./data
+COPY --from=builder --chown=nextjs:nodejs /app/public ./public
 
 USER nextjs
 


### PR DESCRIPTION
### Description of the Change

After adding PWA manifest in #89 I realized that requests to `manifest.json` fail with a 404 error, this seems to be because in the Docker deployment the `public` directory seems to be missing. I confirmed this by checking for `robots.txt` which also results in a 404 on my Docker deployment.

### Possible Drawbacks

--